### PR TITLE
Update VotingApiWidgetBase

### DIFF
--- a/src/Plugin/VotingApiWidgetBase.php
+++ b/src/Plugin/VotingApiWidgetBase.php
@@ -97,7 +97,7 @@ abstract class VotingApiWidgetBase extends PluginBase implements VotingApiWidget
     }
 
     // Check for rollover 'never' setting.
-    if (!empty($timestamp_offset) && $timestamp_offset != -1) {
+    if (!empty($timestamp_offset)) {
       $query->condition('timestamp', time() - $timestamp_offset, '>=');
     }
 


### PR DESCRIPTION
getWindow() should never return -1.
this was introduced due to a bug which will be fixed by this pull request:
https://github.com/b-connect/votingapi_widgets/pull/2