### PR TITLE
Fix some bugs on custom fieldFormatter and Settings

### DIFF
--- a/src/Plugin/Field/FieldFormatter/VotingApiFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/VotingApiFormatter.php
@@ -24,12 +24,12 @@ class VotingApiFormatter extends FormatterBase {
    */
   public static function defaultSettings() {
     return [
-      'readonly' => FALSE,
-      'style' => 'default',
-      'show_results' => FALSE,
-      'values' => [],
-      // Implement default settings.
-    ] + parent::defaultSettings();
+        'readonly'     => FALSE,
+        'style'        => 'default',
+        'show_results' => FALSE,
+        'values'       => [],
+        // Implement default settings.
+      ] + parent::defaultSettings();
   }
 
   /**
@@ -54,24 +54,24 @@ class VotingApiFormatter extends FormatterBase {
     }
 
     return [
-      // Implement settings form.
-	    'style' => [
-				'#title' => t('Styles'),
-				'#type' => 'select',
-				'#options' => $styles,
-				'#default_value' => $this->getSetting('style'),
-	    ],
-      'readonly' => [
-				'#title' => t('Readonly'),
-        '#type' => 'checkbox',
-        '#default_value' => $this->getSetting('readonly'),
-      ],
-      'show_results' => [
-        '#title' => t('Show results'),
-        '#type' => 'checkbox',
-        '#default_value' => $this->getSetting('show_results'),
-      ],
-    ] + parent::settingsForm($form, $form_state);
+        // Implement settings form.
+        'style'        => [
+          '#title'         => t('Styles'),
+          '#type'          => 'select',
+          '#options'       => $styles,
+          '#default_value' => $this->getSetting('style'),
+        ],
+        'readonly'     => [
+          '#title'         => t('Readonly'),
+          '#type'          => 'checkbox',
+          '#default_value' => $this->getSetting('readonly'),
+        ],
+        'show_results' => [
+          '#title'         => t('Show results'),
+          '#type'          => 'checkbox',
+          '#default_value' => $this->getSetting('show_results'),
+        ],
+      ] + parent::settingsForm($form, $form_state);
   }
 
   /**
@@ -106,8 +106,9 @@ class VotingApiFormatter extends FormatterBase {
 
     $elements[] = [
       'vote_form' => [
-        '#lazy_builder' => [
-          'voting_api.lazy_loader:buildForm', [
+        '#lazy_builder'       => [
+          'voting_api.lazy_loader:buildForm',
+          [
             $vote_plugin,
             $entity->getEntityTypeId(),
             $entity->bundle(),
@@ -121,7 +122,7 @@ class VotingApiFormatter extends FormatterBase {
         ],
         '#create_placeholder' => TRUE,
       ],
-      'results' => [],
+      'results'   => [],
     ];
 
     return $elements;

--- a/src/Plugin/Field/FieldFormatter/VotingApiFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/VotingApiFormatter.php
@@ -55,16 +55,16 @@ class VotingApiFormatter extends FormatterBase {
 
     return [
       // Implement settings form.
+	    'style' => [
+				'#title' => t('Styles'),
+				'#type' => 'select',
+				'#options' => $styles,
+				'#default_value' => $this->getSetting('style'),
+	    ],
       'readonly' => [
-        '#title' => t('Readonly'),
+				'#title' => t('Readonly'),
         '#type' => 'checkbox',
         '#default_value' => $this->getSetting('readonly'),
-      ],
-      'style' => [
-        '#title' => t('Styles'),
-        '#type' => 'select',
-        '#options' => $styles,
-        '#default_value' => $this->getSetting('style'),
       ],
       'show_results' => [
         '#title' => t('Show results'),
@@ -79,7 +79,10 @@ class VotingApiFormatter extends FormatterBase {
    */
   public function settingsSummary() {
     $summary = [];
-    // @TODO: Create a summary.
+    $summary[] = t('Styles: @styles', ['@styles' => $this->getSetting('style')]);
+    $summary[] = t('Readonly: @readonly', ['@readonly' => $this->getSetting('readonly') ? t('yes') : t('no')]);
+    $summary[] = t('Show results: @results', ['@results' => $this->getSetting('show_results') ? t('yes') : t('no')]);
+
     return $summary;
   }
 
@@ -97,7 +100,7 @@ class VotingApiFormatter extends FormatterBase {
     $vote_plugin = $field_settings['vote_plugin'];
     $readonly = $this->getSetting('readonly');
 
-      if ($items->status === "0") {
+    if ($items->status === "0") {
       $readonly = TRUE;
     }
 

--- a/src/Plugin/Field/FieldFormatter/VotingApiFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/VotingApiFormatter.php
@@ -69,7 +69,7 @@ class VotingApiFormatter extends FormatterBase {
       'show_results' => [
         '#title' => t('Show results'),
         '#type' => 'checkbox',
-        '#default_value' => $this->getSetting('style'),
+        '#default_value' => $this->getSetting('show_results'),
       ],
     ] + parent::settingsForm($form, $form_state);
   }
@@ -97,7 +97,7 @@ class VotingApiFormatter extends FormatterBase {
     $vote_plugin = $field_settings['vote_plugin'];
     $readonly = $this->getSetting('readonly');
 
-    if (!$items->status) {
+      if ($items->status === "0") {
       $readonly = TRUE;
     }
 

--- a/src/Plugin/Field/FieldWidget/VotingApiWidget.php
+++ b/src/Plugin/Field/FieldWidget/VotingApiWidget.php
@@ -26,7 +26,7 @@ class VotingApiWidget extends WidgetBase {
     $element['status'] = array(
       '#type' => 'radios',
       '#title' => t('Votes'),
-      '#default_value' => 1,
+      '#default_value' => isset($items->getValue('status')[0]['status']) ? $items->getValue('status')[0]['status'] : 1,
       '#options' => array(
         1 => t('Open'),
         0 => t('Closed'),


### PR DESCRIPTION
bugfixes:
- field formatter settings does not display correctly
- field "status" will be NULL on existing content, thus the widget will be readonly until you save the node manually
- field "status" does not display correctly

features:
- reorder settings form and added settingsSummary
